### PR TITLE
Fix super call of request method

### DIFF
--- a/valve/source/a2s.py
+++ b/valve/source/a2s.py
@@ -25,7 +25,8 @@ class ServerQuerier(valve.source.BaseQuerier):
     """
 
     def request(self, request):
-        self.request(messages.Header(split=messages.NO_SPLIT), request)
+        super(ServerQuerier, self).request(
+            messages.Header(split=messages.NO_SPLIT), request)
 
     def get_response(self):
 


### PR DESCRIPTION
`ServerQuerier.request` was calling itself instead of `BaseQuerier.request`.

Resolves #51