### PR TITLE
Fixes #60. Adds support for RCON Servers that do not support Multiple Packet Respones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _build/
 build/
 dist/
 htmlcov/
+T
 
 .coverage
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setuptools.setup(
         "test": [
             "mock==1.0.1",
             "pytest>=2.8.0",
-            "pytest-capturelog",
             "pytest-cov",
             "pytest-timeout",
         ],

--- a/valve/rcon.py
+++ b/valve/rcon.py
@@ -31,9 +31,9 @@ log = logging.getLogger(__name__)
 # See: https://github.com/docopt/docopt/issues/41
 _USAGE = """
 Usage:
-  {program}
-  {program} ADDRESS [-np PASSWORD]
-  {program} ADDRESS -n -p PASSWORD -e COMMAND
+  {program} [-n]
+  {program} ADDRESS [-p PASSWORD] [-n]
+  {program} ADDRESS -p PASSWORD [-n] -e COMMAND
 
 Arguments:
   ADDRESS       Address of the server to connect to. If the port number

--- a/valve/rcon.py
+++ b/valve/rcon.py
@@ -623,6 +623,10 @@ def execute(address, password, command, multi_part=True):
         containing the host as a string and the port as an integer.
     :param str password: the password to use to authenticate the connection.
     :param str command: the command to execute on the server.
+    :param bool multi_part: flag for if RCON server supports
+        `Multiple Packet Responses`_.
+
+    .. _Multiple Packet Responses: https://developer.valvesoftware.com/wiki/Source_RCON_Protocol#Multiple-packet_Responses
 
     :raises UnicodeDecodeError: if the response could not be decoded into
         Unicode.
@@ -870,6 +874,7 @@ class _RCONShell(cmd.Cmd):
         """Shutdown the connected server."""
         self.default("exit")
 
+
 def shell(address=None, password=None, multi_part=True):
     """A simple interactive RCON shell.
 
@@ -885,6 +890,10 @@ def shell(address=None, password=None, multi_part=True):
         of the RCON server.
     :param str password: the password for the server. This is ignored if
         ``address`` is not given.
+    :param bool multi_part: flag for if RCON server supports
+        `Multiple Packet Responses`_.
+
+    .. _Multiple Packet Responses: https://developer.valvesoftware.com/wiki/Source_RCON_Protocol#Multiple-packet_Responses
     """
     rcon_shell = _RCONShell(multi_part)
     try:


### PR DESCRIPTION
* Adds new parameter to RCON (multi_part) that is a flag for if the RCON server support Multiple Packet Responses
* Updates _ResponseBuffer to handle single packet respones
* Adds multi_part parameter to shell and everything else in rcon.py that initializes RCON class
* Adds and updates Unit tests and docs reflecting above changes

Unrelated changes:
* removes pytest-capturelog to remove a warning from py.test. pytest-capturelog has been merged into py.test core

**Note on tests**: I am not sure why the 3.6 tests are failing. I developed this with 3.6.3 (same version as Travis) on Arch Linux. The tests pass just fine on my system. I wonder if Travis is acting up or is there something I am missing?
