### PR TITLE
valve.source.a2s - BaseQuerier bug fixed

### DIFF
--- a/valve/source/a2s.py
+++ b/valve/source/a2s.py
@@ -49,7 +49,7 @@ class ServerQuerier(valve.source.BaseQuerier):
                 raise NotImplementedError("Fragments are compressed")
             fragments[fragment["fragment_id"]] = fragment
             while len(fragments) < fragment["fragment_count"]:
-                data = BaseQuerier.get_response(self)
+                data = valve.source.BaseQuerier.get_response(self)
                 fragment = messages.Fragment.decode(
                     messages.Header.decode(data).payload)
                 fragments[fragment["fragment_id"]] = fragment


### PR DESCRIPTION
Hi! This is my little fix. =)

```
  import valve.source.master_server
  import valve.source.a2s

  with valve.source.master_server.MasterServerQuerier() as m_msq:
    m_servers = m_msq.find(
        region=("eu", ),
        duplicates="skip",
        gamedir="cstrike",
        map="de_dust2",
    )

    for m_host, m_port in m_servers:
      with valve.source.a2s.ServerQuerier((m_host, m_port)) as m_query: m_query.rules()
```

sometimes we have:
```
Traceback (most recent call last):
  File "show-me-bug.py", line 17, in <module>
    with valve.source.a2s.ServerQuerier((m_host, m_port)) as m_query: m_query.rules()
  File "/usr/local/lib/python3.7/dist-packages/valve/source/a2s.py", line 228, in rules
    return messages.RulesResponse.decode(self.get_response())
  File "/usr/local/lib/python3.7/dist-packages/valve/source/a2s.py", line 52, in get_response
    data = BaseQuerier.get_response(self)
NameError: name 'BaseQuerier' is not defined
```