### PR TITLE
collections.Mapping Errors Fix

### DIFF
--- a/valve/source/messages.py
+++ b/valve/source/messages.py
@@ -376,7 +376,7 @@ class MessageDictField(MessageArrayField):
         return entries_dict, buffer
 
 
-class Message(collections.Mapping):
+class Message(collections.abc.Mapping): # edited
 
     fields = ()
 


### PR DESCRIPTION
change to collections.abc.Mapping from collections.Mapping as collections.Mapping is deprecated as of now